### PR TITLE
interleaveMany

### DIFF
--- a/src/Data/List/Infinite.hs
+++ b/src/Data/List/Infinite.hs
@@ -53,7 +53,6 @@ module Data.List.Infinite (
   intersperse,
   intercalate,
   interleave,
-  interleaves,
   interleaveMany,
   transpose,
   subsequences,
@@ -406,14 +405,6 @@ concatMap f = foldr1 (\a acc -> let (x :| xs) = f a in x :< (xs `prependList` ac
 -- | Interleave two infinite lists.
 interleave :: Infinite a -> Infinite a -> Infinite a
 interleave (x :< xs) ys = x :< interleave ys xs
-
--- | Interleave N infinite lists.
-interleaves :: NonEmpty (Infinite a) -> Infinite a
-interleaves = go id . NE.toList where
-  go f ((a:<as):ass) =
-    a :< go (\z -> f (as:z)) ass
-  go f _ =
-    go id (f [])
 
 -- |   interleaveMany = foldr1 interleave
 interleaveMany :: NonEmpty (Infinite a) -> Infinite a


### PR DESCRIPTION
`interleaveMany = foldr1 interleave` but about 30% faster and with 20% less `malloc` calls. That's not a huge improvement, but an improvement non the less!

```haskell
interleaveMany :: Infinite (Infinite a) -> Infinite a
```
It is strict in the first 64 elements of the "outer" infinite list, but lazy in the the "inner" ones.

It is possible to make the outer list finite, ie `NonEmpty (Infinite a) -> Infinite a`, by capping the index to however many elements there are ```i = 63 `min` ctz x `min` length lists - 1```.