### PR TITLE
replace !! in >>= by genericDrop

### DIFF
--- a/src/Data/List/Infinite.hs
+++ b/src/Data/List/Infinite.hs
@@ -330,7 +330,9 @@ instance Applicative Infinite where
 instance Monad Infinite where
   xs >>= f = go 0 xs
     where
-      go !n (y :< ys) = f y !! n :< go (n + 1) ys
+      go !n (y :< ys) = ((f y) `index` n) :< go (n + 1) ys
+      index :: Infinite a -> Natural -> a
+      index ys n = head (genericDrop n ys)
   {-# INLINE (>>=) #-}
   (>>) = (*>)
 


### PR DESCRIPTION
`(!!)` works as intended only for indices up to `maxBound :: Word`. As a result, the `Monad` instance is not lawful. A more generic version using `genericDrop`  and `Natural` as index type resolves [this issue](https://github.com/Bodigrim/infinite-list/issues/7).